### PR TITLE
hotfix - alert user if their account is not legitimate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# CHANGELOG
+
+## [Unreleased]
+
+## [1.0.0] - 2022-04-13
+
+- Initial release of the Faucet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [1.0.1] - 2022-04-14
+
+ - Alert user if their account is not valid [#29](https://github.com/cennznet/app-faucet/pull/29)
+
 ## [1.0.0] - 2022-04-13
 
 - Initial release of the Faucet

--- a/libs/components/FaucetButton.tsx
+++ b/libs/components/FaucetButton.tsx
@@ -10,11 +10,11 @@ const FaucetButton: VFC = () => {
 	useEffect(() => {
 		if (!session || warned) return;
 
-		if (!session.validAccount) {
+		if (session.validAccount) {
 			alert(
-				`${
-					session.user.name ?? "Your Twitter account"
-				} has failed our legitimacy checks. Please ensure your account has at least 1 tweet, 15 followers, and is older than 1 month.`
+				`Please ensure ${
+					session.user.name ?? "your Twitter account"
+				} has at least 1 tweet, 15 followers, and is older than 1 month.`
 			);
 			setWarned(true);
 		}

--- a/libs/components/FaucetButton.tsx
+++ b/libs/components/FaucetButton.tsx
@@ -1,10 +1,24 @@
-import { FC } from "react";
+import { VFC, useEffect, useState } from "react";
 import { css } from "@emotion/react";
 import { signIn, useSession } from "next-auth/react";
 import { Theme } from "@mui/material";
 
-const FaucetButton: FC = () => {
+const FaucetButton: VFC = () => {
 	const { data: session } = useSession();
+	const [warned, setWarned] = useState<boolean>(false);
+
+	useEffect(() => {
+		if (!session || warned) return;
+
+		if (!session.validAccount) {
+			alert(
+				`${
+					session.user.name ?? "Your Twitter account"
+				} has failed our legitimacy checks. Please ensure your account has at least 1 tweet, 15 followers, and is older than 1 month.`
+			);
+			setWarned(true);
+		}
+	}, [session, warned]);
 
 	return (
 		<>

--- a/libs/components/FaucetButton.tsx
+++ b/libs/components/FaucetButton.tsx
@@ -10,7 +10,7 @@ const FaucetButton: VFC = () => {
 	useEffect(() => {
 		if (!session || warned) return;
 
-		if (session.validAccount) {
+		if (!session.validAccount) {
 			alert(
 				`Please ensure ${
 					session.user.name ?? "your Twitter account"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-faucet",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "engines": {
     "node": "<=16.14.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-faucet",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "engines": {
     "node": "<=16.14.0"


### PR DESCRIPTION
## Description

 - if `!session.validAccount` alert user their account is not legitimate

## Notes

 - I approached the issue this way as returning false as discussed only leaves the user with this page:
 ![Screen Shot 2022-04-14 at 12 38 45 PM (2)](https://user-images.githubusercontent.com/52016903/163292131-0cdf4f5b-791a-41c9-b139-1884b17cf2b8.png)


